### PR TITLE
Added "Edit.LineFirstColumn" as a recordable command

### DIFF
--- a/Model/RecordableCommands.cs
+++ b/Model/RecordableCommands.cs
@@ -71,7 +71,9 @@ namespace VSTextMacros.Model
                     (uint)VSConstants.VSStd2KCmdID.DELETELINE,
                     (uint)VSConstants.VSStd2KCmdID.DELETEBLANKLINES,
                     (uint)VSConstants.VSStd2KCmdID.INDENT,
-                    (uint)VSConstants.VSStd2KCmdID.UNINDENT
+                    (uint)VSConstants.VSStd2KCmdID.UNINDENT,
+                    (uint)VSConstants.VSStd2KCmdId.EditorLineFirstColumn, //Editor line first column (Edit.LineFirstColumn)
+                    (uint)VSConstants.VSStd2KCmdId.EditorLineFirstColumnExtend //Editor line first column extended (Edit.LineFirstColumnExtend)
                 }
             },
             {


### PR DESCRIPTION
Added support for the `Edit.LineFirstColumn` and `Edit.LineFirstColumnExtend` commands. 

**Edit.LineFirstColumn** moves the cursor to the beginning of the line. 

This is in contrast to **Edit.LineStart** which toggles the cursor between the _first character_ of the line and the _start of the line_.
