### PR TITLE
Fixed .NET dependency check causing VS2013 install to fail

### DIFF
--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -14,7 +14,7 @@
 		<InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,14.0]" />
 	</Installation>
 	<Dependencies>
-		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" MinVersion="4.5" />
+		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,]" />
 		<Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="11.0" />
 	</Dependencies>
 	<Assets>


### PR DESCRIPTION
Changed the dependency version checking to use a version range instead
of MinVersion, which was causing the install to fail in VS2013