### PR TITLE
Add support for custom user commands

### DIFF
--- a/Model/MacroCommand.cs
+++ b/Model/MacroCommand.cs
@@ -10,4 +10,11 @@ namespace VSTextMacros.Model
         public uint CommandOptions { get; set; }
         public char? Character { get; set; }
     }
+
+    public class MacroCustomCommand
+    {
+        public Guid Group;
+        public uint ID;
+        public String Cmd;
+    };
 }

--- a/VSTextMacrosPackage.cs
+++ b/VSTextMacrosPackage.cs
@@ -38,6 +38,8 @@ namespace VSTextMacros
 			if (File.Exists(Path.Combine(MacroDirectory, "Current.xml")))
 				Macro.CurrentMacro = Macro.LoadFromFile(Path.Combine(MacroDirectory, "Current.xml"));
 
+			RecordableCommands.AddFromFile(Path.Combine(MacroDirectory, "Custom.xml"));
+
 			DTE = (DTE2)await GetServiceAsync(typeof(DTE));
 
 			await base.InitializeAsync(cancellationToken, progress);


### PR DESCRIPTION
This PR adds the ability for a user to create their own set of commands that are allowed by the macro system.  The commands are executed either by ID or by textual command.  The commands are entered in a 'Custom.xml' file that gets read when the extension starts.  This feature was created because I have my own extension with a handful of useful (to me anyway) editing utilities, and they were not functioning in the macro system.  Instead of just patching the extension for myself, I thought a generalized solution would be useful to others as well. 

changes:
- Add support for custom user commands
- Moved special-case find commands into normal processing path (was not checking guid anyway)

